### PR TITLE
chore: personaliza portas para aplicação e banco de dados

### DIFF
--- a/.github/workflows/bdd-tests.yaml
+++ b/.github/workflows/bdd-tests.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Wait for services to be ready
         run: |
-          until [ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/api/v1/health-check)" -eq 200 ]; do
+          until [ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8082/api/v1/health-check)" -eq 200 ]; do
             echo "Waiting for the service to be ready..."
             sleep 5
           done

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,17 @@ FROM openjdk:17-slim
 # Define o WORKDIR no container
 WORKDIR /app
 
+ARG PROFILE=prod
+ENV PROFILE=${PROFILE}
+
 # Copia o JAR da aplicacao para o WORKDIR
 COPY --from=build /app/target/*.jar ./app.jar
 
 # Executa a aplicacao
-CMD ["java", "-Dspring.profiles.active=prod", "-Dlogging.level.root=DEBUG", "-jar", "app.jar"]
+CMD ["java", "-Dspring.profiles.active=${PROFILE}", "-Dlogging.level.root=DEBUG", "-jar", "app.jar"]
 
 # Build e envio da imagem para o Docker Hub
 # docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile -t carlohcs/food-cliente:1 . --push
 
 # Rodando a aplicação
-# docker run -it --platform linux/amd64 -p 8080:8080 carlohcs/food-cliente:1
+# docker run -it --platform linux/amd64 -p 8082:8082 carlohcs/food-cliente:1

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A interação da aplicação se dá através de APIs com o Swagger disponibiliza
 3. Clique em `Run workflow` (ou Executar workflow);
 4. Aguarde. Se tudo der certo, o `check` verde deverá aparecer - o processo dura em torno de 2 minutos;
 
-![applicacao-atualizada-sucesso](./docs/aplicacao-atualizada-sucesso.png)
+![applicacao-atualizada-sucesso](docs/aplicacao-atualizada-sucesso.png)
 
 Para acessar a aplicação é necessário acessar a URL da através do Kubernetes, acessando a área de Services e acessando ao serviço `food-cliente`.
 A URL será algo como: [http://aa326084c74cf48c6a15f7832f4edb95-21c002b943a9cff6.elb.us-east-1.amazonaws.com:8080/api-docs](http://aa326084c74cf48c6a15f7832f4edb95-21c002b943a9cff6.elb.us-east-1.amazonaws.com:8080/api-docs).
@@ -67,7 +67,7 @@ docker compose up
 
 Acesse a aplicação da API em:
 
-[http://localhost:8080/api-docs](http://localhost:8080/api-docs)
+[http://localhost:8082/api-docs](http://localhost:8082/api-docs)
 
 </details>
 
@@ -110,7 +110,7 @@ mvn clean test -P unit-tests
 
 Você poderá ver o relatório de cobertura de testes em `target/site/jacoco/index.html`.
 
-![jacoco-coverage.png](./docs/jacoco-coverage.png)
+![jacoco-coverage.png](docs/jacoco-coverage.png)
 
 Além disso, é possível ver o coverage atualizado nesta página, ao lado do título do repositório.
 
@@ -143,7 +143,7 @@ mvn clean test -P bdd-tests
 
 Você poderá ver o relatório de cobertura de testes em `target/cucumber-reports/cucumber.html`.
 
-![cucumber-coverage.png](./docs/cucumber-coverage.png)
+![cucumber-coverage.png](docs/cucumber-coverage.png)
 
 </details>
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,16 +3,16 @@ docker build --no-cache --platform linux/amd64 -f Dockerfile.prod.yml \
   --build-arg MYSQL_DATABASE=mydatabase \
   --build-arg MYSQL_USER=myuser \
   --build-arg MYSQL_PASSWORD=mypassword \
-  --build-arg SPRING_CLIENTE_DATASOURCE_URL=jdbc:mysql://localhost:3306/mydatabase \
+  --build-arg SPRING_CLIENTE_DATASOURCE_URL=jdbc:mysql://localhost:3307/mydatabase \
   --build-arg FOOD_CLIENTE_DATASOURCE_USERNAME=myuser \
   --build-arg FOOD_CLIENTE_DATASOURCE_PASSWORD=mypassword \
   --build-arg FOOD_CLIENTE_VERSION=latest \
   --build-arg APPLICATION_DATABASE_VERSION=latest \
-  --build-arg FOOD_CLIENTE_PORT=8080 \
+  --build-arg FOOD_CLIENTE_PORT=8082 \
   -t carlohcs/food-repo:withoutdb16 .
 
 docker push carlohcs/food-repo:withoutdb13
-docker run -p 8080:8080 carlohcs/food-repo:withoutdb11
+docker run -p 8082:8082 carlohcs/food-repo:withoutdb11
 
 
 docker buildx build --platform=linux/amd64 -f Dockerfile.prod.yml \
@@ -20,10 +20,10 @@ docker buildx build --platform=linux/amd64 -f Dockerfile.prod.yml \
   --build-arg MYSQL_DATABASE=mydatabase \
   --build-arg MYSQL_USER=myuser \
   --build-arg MYSQL_PASSWORD=mypassword \
-  --build-arg SPRING_CLIENTE_DATASOURCE_URL=jdbc:mysql://localhost:3306/mydatabase \
+  --build-arg SPRING_CLIENTE_DATASOURCE_URL=jdbc:mysql://localhost:3307/mydatabase \
   --build-arg FOOD_CLIENTE_DATASOURCE_USERNAME=myuser \
   --build-arg FOOD_CLIENTE_DATASOURCE_PASSWORD=mypassword \
   --build-arg FOOD_CLIENTE_VERSION=latest \
   --build-arg APPLICATION_DATABASE_VERSION=latest \
-  --build-arg FOOD_CLIENTE_PORT=8080 \
+  --build-arg FOOD_CLIENTE_PORT=8082 \
   -t carlohcs/food-repo:withoutdb18 . --push

--- a/config/env/dev.env
+++ b/config/env/dev.env
@@ -1,7 +1,7 @@
 # Aplicação
 FOOD_CLIENTE_VERSION=latest
 APPLICATION_DATABASE_VERSION=latest
-APPLICATION_PORT=8080
+APPLICATION_PORT=8082
 ENABLE_FLYWAY=false
 
 # MySQL config
@@ -11,6 +11,6 @@ MYSQL_USER=foodcliente
 MYSQL_PASSWORD=foodcliente
 
 # Spring database config
-SPRING_CLIENTE_DATASOURCE_URL=jdbc:mysql://localhost:8080/foodclientedb
+SPRING_CLIENTE_DATASOURCE_URL=jdbc:mysql://localhost:8082/foodclientedb
 FOOD_CLIENTE_DATASOURCE_USERNAME=foodcliente
 FOOD_CLIENTE_DATASOURCE_PASSWORD=foodcliente

--- a/config/env/local.env
+++ b/config/env/local.env
@@ -1,7 +1,7 @@
 # Aplicação
 FOOD_CLIENTE_VERSION=latest
 APPLICATION_DATABASE_VERSION=latest
-APPLICATION_PORT=8080
+APPLICATION_PORT=8082
 ENABLE_FLYWAY=true
 
 # MySQL config
@@ -9,8 +9,9 @@ MYSQL_ROOT_PASSWORD=root
 MYSQL_DATABASE=foodclientedb
 MYSQL_USER=foodcliente
 MYSQL_PASSWORD=foodcliente
+MYSQL_TCP_PORT=3307
 
 # Spring database config
-SPRING_CLIENTE_DATASOURCE_URL=jdbc:mysql://localhost:3306/foodclientedb
+SPRING_CLIENTE_DATASOURCE_URL=jdbc:mysql://localhost:3307/foodclientedb
 FOOD_CLIENTE_DATASOURCE_USERNAME=foodcliente
 FOOD_CLIENTE_DATASOURCE_PASSWORD=foodcliente

--- a/config/env/prod.env
+++ b/config/env/prod.env
@@ -1,7 +1,7 @@
 # Aplicação
 FOOD_CLIENTE_VERSION=latest
 APPLICATION_DATABASE_VERSION=latest
-APPLICATION_PORT=8080
+APPLICATION_PORT=8082
 ENABLE_FLYWAY=false
 
 # MySQL config
@@ -11,6 +11,6 @@ MYSQL_USER=foodcliente
 MYSQL_PASSWORD=foodcliente
 
 # Spring database config
-SPRING_CLIENTE_DATASOURCE_URL=jdbc:mysql://mysqldb:3306/foodclientedb
+SPRING_CLIENTE_DATASOURCE_URL=jdbc:mysql://mysqlclientedb:3307/foodclientedb
 FOOD_CLIENTE_DATASOURCE_USERNAME=foodcliente
 FOOD_CLIENTE_DATASOURCE_PASSWORD=foodcliente

--- a/config/env/test.env
+++ b/config/env/test.env
@@ -1,7 +1,7 @@
 # Aplicação
 FOOD_CLIENTE_VERSION=latest
 APPLICATION_DATABASE_VERSION=latest
-APPLICATION_PORT=8080
+APPLICATION_PORT=8082
 ENABLE_FLYWAY=true
 
 # MySQL config
@@ -9,8 +9,9 @@ MYSQL_ROOT_PASSWORD=root
 MYSQL_DATABASE=foodclientedb
 MYSQL_USER=foodcliente
 MYSQL_PASSWORD=foodcliente
+MYSQL_TCP_PORT=3307
 
 # Spring database config
-SPRING_CLIENTE_DATASOURCE_URL=jdbc:mysql://mysqldb:3306/foodclientedb
+SPRING_CLIENTE_DATASOURCE_URL=jdbc:mysql://mysqlclientedb:3307/foodclientedb
 FOOD_CLIENTE_DATASOURCE_USERNAME=foodcliente
 FOOD_CLIENTE_DATASOURCE_PASSWORD=foodcliente

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,12 @@ volumes:
   mysql_data: {}
 
 services:
-  mysqldb:
+  mysqlclientedb:
     image: mysql:8.0
     volumes: 
       - ./mysql_data:/var/lib/mysql
     ports:
-      - "3306:3306"
+      - "3307:3307"
     networks:
       - foodapi-network
     restart: always
@@ -28,9 +28,9 @@ services:
       - config/env/test.env
     build: .
     depends_on:
-      mysqldb:
+      mysqlclientedb:
         condition: service_healthy
     ports:
-      - "8080:8080"
+      - "8082:8082"
 networks:
   foodapi-network:

--- a/pom.xml
+++ b/pom.xml
@@ -26,15 +26,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>3.2.5</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>3.2.5</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,14 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <version>3.2.5</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <version>3.2.5</version>
             <scope>test</scope>
         </dependency>
 
@@ -106,12 +109,14 @@
             <version>5.3.0</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>5.3.1</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
@@ -136,12 +141,14 @@
             <version>7.13.0</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-junit-platform-engine</artifactId>
             <version>7.13.0</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite</artifactId>
@@ -149,6 +156,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-spring</artifactId>
+            <version>7.20.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,9 +1,9 @@
 # Config do banco de dados MySQL
-spring.datasource.url=${SPRING_CLIENTE_DATASOURCE_URL:jdbc:mysql://localhost:3306/foodclientedb}
+spring.datasource.url=${SPRING_CLIENTE_DATASOURCE_URL:jdbc:mysql://localhost:3307/foodclientedb}
 spring.datasource.username=${FOOD_CLIENTE_DATASOURCE_USERNAME:foodcliente}
 spring.datasource.password=${FOOD_CLIENTE_DATASOURCE_PASSWORD:foodcliente}
 # Configuração para ignorar falhas de conexão com o banco de dados
 spring.sql.init.continue-on-error=true
 
 # Server
-server.port=${APPLICATION_PORT:8080}
+server.port=${APPLICATION_PORT:8082}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@ application.database.version=${APPLICATION_DATABASE_VERSION:latest}
 
 # Config do banco de dados MySQL
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=${SPRING_CLIENTE_DATASOURCE_URL:jdbc:mysql://localhost:3306/foodclientedb}
+spring.datasource.url=${SPRING_CLIENTE_DATASOURCE_URL:jdbc:mysql://localhost:3307/foodclientedb}
 spring.datasource.username=${FOOD_CLIENTE_DATASOURCE_USERNAME:foodcliente}
 spring.datasource.password=${FOOD_CLIENTE_DATASOURCE_PASSWORD:foodcliente}
 
@@ -31,7 +31,7 @@ logging.level.org.springframework.data.jpa=TRACE
 logging.level.org.hibernate.SQL=debug
 
 # Server
-server.port=${APPLICATION_PORT:8080}
+server.port=${APPLICATION_PORT:8082}
 
 # Swagger
 springdoc.swagger-ui.disable-swagger-default-url=true

--- a/src/test/java/br/com/alfac/foodcliente/bdd/CucumberSpringConfiguration.java
+++ b/src/test/java/br/com/alfac/foodcliente/bdd/CucumberSpringConfiguration.java
@@ -1,0 +1,9 @@
+package br.com.alfac.foodcliente.bdd;
+
+import io.cucumber.spring.CucumberContextConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@CucumberContextConfiguration
+@SpringBootTest
+public class CucumberSpringConfiguration {
+}

--- a/src/test/java/br/com/alfac/foodcliente/bdd/PassosClienteTest.java
+++ b/src/test/java/br/com/alfac/foodcliente/bdd/PassosClienteTest.java
@@ -6,6 +6,8 @@ import io.cucumber.java.pt.Dado;
 import io.cucumber.java.pt.Então;
 import io.cucumber.java.pt.Quando;
 import io.restassured.response.Response;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import br.com.alfac.foodcliente.utils.ClienteHelper;
@@ -20,8 +22,16 @@ public class PassosClienteTest {
 
     private Cliente clienteResponse;
 
-    private String FULL_ENDPOINT_CLIENTES = "http://localhost:8080/api/v1/clientes";
-    
+    private String FULL_ENDPOINT_CLIENTES;
+
+    @Value("${server.port}")
+    private String applicationPort;
+
+    @PostConstruct
+    public void init() {
+        FULL_ENDPOINT_CLIENTES = "http://localhost:" + applicationPort + "/api/v1/clientes";
+    }
+
     @Quando("criar um novo cliente")
     public void criarNovoCliente() {
         var clienteRequest = ClienteHelper.criarClienteRequest();
@@ -54,7 +64,7 @@ public class PassosClienteTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(clienteRequest)
                 .when().post(FULL_ENDPOINT_CLIENTES);
-        
+
         clienteResponse = response.then().extract().as(Cliente.class);
         clienteResponse.setCpf(new CPF(clienteRequest.getCpf()));
     }


### PR DESCRIPTION
# Descrição

- Personaliza a porta da aplicação para `8082` localmente, haja visto que ao executar localmente, estamos tendo conflitos;
- Personaliza a porta e nome do banco de dados para evitar colisão com outras aplicações localmente;